### PR TITLE
checking the affect of removing @emotion/react

### DIFF
--- a/examples/material-ui/app/entry.client.tsx
+++ b/examples/material-ui/app/entry.client.tsx
@@ -1,21 +1,4 @@
-import * as React from 'react';
-import { hydrate } from 'react-dom';
-import { RemixBrowser } from 'remix';
-import { CacheProvider, ThemeProvider } from '@emotion/react';
-import CssBaseline from '@mui/material/CssBaseline';
+import { hydrate } from "react-dom";
+import { RemixBrowser } from "remix";
 
-import createEmotionCache from './src/createEmotionCache';
-import theme from './src/theme';
-
-const emotionCache = createEmotionCache();
-
-hydrate(
-  <CacheProvider value={emotionCache}>
-    <ThemeProvider theme={theme}>
-      {/* CssBaseline kickstart an elegant, consistent, and simple baseline to build upon. */}
-      <CssBaseline />
-      <RemixBrowser />
-    </ThemeProvider>
-  </CacheProvider>,
-  document,
-);
+hydrate(<RemixBrowser />, document);

--- a/examples/material-ui/app/entry.server.tsx
+++ b/examples/material-ui/app/entry.server.tsx
@@ -1,59 +1,21 @@
-import * as React from 'react';
-import { renderToString } from 'react-dom/server';
-import { RemixServer } from 'remix';
-import type { EntryContext } from 'remix';
-
-import createEmotionCache from './src/createEmotionCache';
-import theme from './src/theme';
-
-import CssBaseline from '@mui/material/CssBaseline';
-import { ThemeProvider } from '@mui/material/styles';
-import { CacheProvider } from '@emotion/react';
-import createEmotionServer from '@emotion/server/create-instance';
+import { renderToString } from "react-dom/server";
+import { RemixServer } from "remix";
+import type { EntryContext } from "remix";
 
 export default function handleRequest(
   request: Request,
   responseStatusCode: number,
   responseHeaders: Headers,
-  remixContext: EntryContext,
+  remixContext: EntryContext
 ) {
-  const cache = createEmotionCache();
-  const { extractCriticalToChunks } = createEmotionServer(cache);
-
-  const MuiRemixServer = () => (
-    <CacheProvider value={cache}>
-      <ThemeProvider theme={theme}>
-        {/* CssBaseline kickstart an elegant, consistent, and simple baseline to build upon. */}
-        <CssBaseline />
-        <RemixServer context={remixContext} url={request.url} />
-      </ThemeProvider>
-    </CacheProvider>
+  const markup = renderToString(
+    <RemixServer context={remixContext} url={request.url} />
   );
 
-  // Render the component to a string.
-  const html = renderToString(<MuiRemixServer />);
+  responseHeaders.set("Content-Type", "text/html");
 
-  // Grab the CSS from emotion
-  const { styles } = extractCriticalToChunks(html);
-
-  let stylesHTML = '';
-
-  styles.forEach(({ key, ids, css }) => {
-    const emotionKey = `${key} ${ids.join(' ')}`;
-    const newStyleTag = `<style data-emotion="${emotionKey}">${css}</style>`;
-    stylesHTML = `${stylesHTML}${newStyleTag}`;
-  });
-
-  // Add the emotion style tags after the insertion point meta tag
-  const markup = html.replace(
-    /<meta(\s)*name="emotion-insertion-point"(\s)*content="emotion-insertion-point"(\s)*\/>/,
-    `<meta name="emotion-insertion-point" content="emotion-insertion-point"/>${stylesHTML}`,
-  );
-
-  responseHeaders.set('Content-Type', 'text/html');
-
-  return new Response(`<!DOCTYPE html>${markup}`, {
+  return new Response("<!DOCTYPE html>" + markup, {
     status: responseStatusCode,
-    headers: responseHeaders,
+    headers: responseHeaders
   });
 }

--- a/examples/material-ui/app/root.tsx
+++ b/examples/material-ui/app/root.tsx
@@ -1,8 +1,14 @@
 import * as React from 'react';
 import { Links, LiveReload, Meta, Outlet, Scripts, ScrollRestoration} from 'remix';
-import theme from './src/theme';
 
-import Layout from './src/Layout';
+import Layout from '~/src/Layout';
+
+
+import createEmotionCache from './src/createEmotionCache';
+import theme from '~/src/theme';
+
+import CssBaseline from '@mui/material/CssBaseline';
+import { ThemeProvider } from '@mui/material/styles';
 
 function Document({ children, title }: { children: React.ReactNode; title?: string }) {
   return (
@@ -17,7 +23,17 @@ function Document({ children, title }: { children: React.ReactNode; title?: stri
         <meta name="emotion-insertion-point" content="emotion-insertion-point" />
       </head>
       <body>
-        {children}
+       
+      <ThemeProvider theme={theme}>
+        {/* CssBaseline kickstart an elegant, consistent, and simple baseline to build upon. */}
+        <CssBaseline />
+        <Layout>
+
+       <Outlet />
+        </Layout>
+      </ThemeProvider>
+
+
         <ScrollRestoration />
         <Scripts />
         {process.env.NODE_ENV === 'development' && <LiveReload />}

--- a/examples/material-ui/app/routes/index.tsx
+++ b/examples/material-ui/app/routes/index.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
 import type { MetaFunction } from 'remix';
-import { Link } from 'remix';
 import Typography from '@mui/material/Typography';
 
 export const meta: MetaFunction = () => {


### PR DESCRIPTION
Hi this PR is more a question than a suggestion.

I there is some code duplication between `entry.server.tsx` & `entry.client.tsx`, I was thinking that maybe a good solution would be to move everything to `root.tsx`.

After I read you code I realized that you implemented it the way you did you wanted to use the `@emotion/cache` as described here https://mui.com/guides/server-rendering/

I wanted to test the affect of removing `@emotion/cache` altogether to release that it works without it and all the MUI styles are injected in the HTML.

Is that a Remix optimization? if so maybe you can drop the use of `@emotion/cache`